### PR TITLE
Revert "fix(deps): update dependency openapi3-ts to v3"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.1.1",
       "license": "MIT",
       "dependencies": {
-        "openapi3-ts": "3.0.2",
+        "openapi3-ts": "2.0.2",
         "yup": "0.32.11"
       },
       "devDependencies": {
@@ -8622,19 +8622,11 @@
       }
     },
     "node_modules/openapi3-ts": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/openapi3-ts/-/openapi3-ts-3.0.2.tgz",
-      "integrity": "sha512-KF/06OkQPFSr9A+oadYYC3cIj8TZlzonREkQYFqx8i+wLllAxm6Bp8Fizo3jWXeIxZj/7V5LKtuNN/GxueWtcw==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/openapi3-ts/-/openapi3-ts-2.0.2.tgz",
+      "integrity": "sha512-TxhYBMoqx9frXyOgnRHufjQfPXomTIHYKhSKJ6jHfj13kS8OEIhvmE8CTuQyKtjjWttAjX5DPxM1vmalEpo8Qw==",
       "dependencies": {
-        "yaml": "^2.1.1"
-      }
-    },
-    "node_modules/openapi3-ts/node_modules/yaml": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.1.1.tgz",
-      "integrity": "sha512-o96x3OPo8GjWeSLF+wOAbrPfhFOGY0W00GNaxCDv+9hkcDJEnev1yh8S7pgHF0ik6zc8sQLuL8hjHjJULZp8bw==",
-      "engines": {
-        "node": ">= 14"
+        "yaml": "^1.10.2"
       }
     },
     "node_modules/optionator": {
@@ -11399,7 +11391,6 @@
       "version": "1.10.2",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
       "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
-      "dev": true,
       "engines": {
         "node": ">= 6"
       }
@@ -17899,18 +17890,11 @@
       }
     },
     "openapi3-ts": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/openapi3-ts/-/openapi3-ts-3.0.2.tgz",
-      "integrity": "sha512-KF/06OkQPFSr9A+oadYYC3cIj8TZlzonREkQYFqx8i+wLllAxm6Bp8Fizo3jWXeIxZj/7V5LKtuNN/GxueWtcw==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/openapi3-ts/-/openapi3-ts-2.0.2.tgz",
+      "integrity": "sha512-TxhYBMoqx9frXyOgnRHufjQfPXomTIHYKhSKJ6jHfj13kS8OEIhvmE8CTuQyKtjjWttAjX5DPxM1vmalEpo8Qw==",
       "requires": {
-        "yaml": "^2.1.1"
-      },
-      "dependencies": {
-        "yaml": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.1.1.tgz",
-          "integrity": "sha512-o96x3OPo8GjWeSLF+wOAbrPfhFOGY0W00GNaxCDv+9hkcDJEnev1yh8S7pgHF0ik6zc8sQLuL8hjHjJULZp8bw=="
-        }
+        "yaml": "^1.10.2"
       }
     },
     "optionator": {
@@ -19906,8 +19890,7 @@
     "yaml": {
       "version": "1.10.2",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
-      "dev": true
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg=="
     },
     "yargs": {
       "version": "17.5.1",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "*.{json,md}": "prettier --write"
   },
   "dependencies": {
-    "openapi3-ts": "3.0.2",
+    "openapi3-ts": "2.0.2",
     "yup": "0.32.11"
   },
   "devDependencies": {


### PR DESCRIPTION
Reverts rudi23/yup-to-openapi#42

Reverting because `openapi3-ts 3.0.2` is [built for node 16](https://github.com/metadevpro/openapi3-ts/blob/master/tsconfig.json#L6), it crashes on Node 12